### PR TITLE
L.Mixin.Events is deprecated in Leaflet 1.2.0

### DIFF
--- a/src/leaflet.almostover.js
+++ b/src/leaflet.almostover.js
@@ -5,7 +5,7 @@ L.Map.mergeOptions({
 
 L.Handler.AlmostOver = L.Handler.extend({
 
-    includes: L.Mixin.Events,
+    includes: L.Evented,
 
     options: {
         distance: 25,   // pixels


### PR DESCRIPTION
Replace L.Mixin.Events with L.Evented