### PR TITLE
Fix error if layer is removed btw over/out events

### DIFF
--- a/src/leaflet.almostover.js
+++ b/src/leaflet.almostover.js
@@ -82,6 +82,7 @@ L.Handler.AlmostOver = L.Handler.extend({
             var index = this._layers.indexOf(layer);
             this._layers.splice(index, 1);
         }
+        this._previous = null;
     },
 
     getClosest: function (latlng) {


### PR DESCRIPTION
Fix an error that occures if "almost:overed" layer is removed between almost:over & almost:out events.