### PR TITLE
Fix removeLayers with unknown layer

### DIFF
--- a/src/leaflet.almostover.js
+++ b/src/leaflet.almostover.js
@@ -89,7 +89,9 @@ L.Handler.AlmostOver = L.Handler.extend({
                 this.unindexLayer(layer);
             }
             var index = this._layers.indexOf(layer);
-            this._layers.splice(index, 1);
+            if (0 <= index) {
+                this._layers.splice(index, 1);
+            }
         }
         this._previous = null;
     },


### PR DESCRIPTION
Hi,

I was removing some layers when I got some surprise when I found that all my layers was removed.
After some investigations, I found this little bug fortunately easy to fix in the removeLayers method.

Thanks for this usefull mobile device's plugin !
